### PR TITLE
remove utility functions & bs58 dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ This is the [multihash](//github.com/multiformats/multihash) implementation in N
 - [API](#api)
   - [`decode(buf)`](#decodebuf)
   - [`encode(digest, hashfn[, length])`](#encodedigest-hashfn-length)
-  - [`toHexString(multihash)`](#tohexstringmultihash)
-  - [`fromHexString(string)`](#fromhexstringstring)
-  - [`toB58String(multihash)`](#tob58stringmultihash)
-  - [`fromB58String(string)`](#fromb58stringstring)
   - [`coerceCode(name)`](#coercecodename)
   - [`isAppCode(code)`](#isappcodecode)
   - [`isValidCode(code)`](#isvalidcodecode)
@@ -113,38 +109,6 @@ Returns an object of the form,
 Encode a hash digest along with the specified function code.
 
 > Note: the length is derived from the length of the digest itself.
-
-Returns a buffer.
-
-### `toHexString(multihash)`
-
-- `multihash: Buffer`
-
-Convert the given multihash to a hex encoded string.
-
-Returns a string.
-
-### `fromHexString(string)`
-
-- `string: String`
-
-Convert the given hex encoded string to a multihash (a `Buffer`).
-
-Returns a buffer.
-
-### `toB58String(multihash)`
-
-- `multihash: Buffer`
-
-Convert the given multihash to a base58 encoded string.
-
-Returns a string.
-
-### `fromB58String(string)`
-
-- `string: String`
-
-Convert the given base58 encoded string to a multihash (a `Buffer`).
 
 Returns a buffer.
 

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
   "bugs": {
     "url": "https://github.com/multiformats/js-multihash/issues"
   },
-  "dependencies": {
-    "bs58": "^3.0.0"
-  },
   "devDependencies": {
     "aegir": "^3.0.1",
     "buffer-equal": "1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,6 @@
 'use strict'
 
-const bs58 = require('bs58')
-
 const cs = require('./constants')
-
-exports.toHexString = function toHexString (m) {
-  if (!Buffer.isBuffer(m)) {
-    throw new Error('must be passed a buffer')
-  }
-
-  return m.toString('hex')
-}
-
-exports.fromHexString = function fromHexString (s) {
-  return new Buffer(s, 'hex')
-}
-
-exports.toB58String = function toB58String (m) {
-  if (!Buffer.isBuffer(m)) {
-    throw new Error('must be passed a buffer')
-  }
-
-  return bs58.encode(m)
-}
-
-exports.fromB58String = function fromB58String (s) {
-  let encoded = s
-  if (Buffer.isBuffer(s)) {
-    encoded = s.toString()
-  }
-
-  return new Buffer(bs58.decode(encoded))
-}
 
 // Decode a hash from the given Multihash.
 exports.decode = function decode (buf) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,7 +3,6 @@
 
 const expect = require('chai').expect
 const bufeq = require('buffer-equal')
-const bs58 = require('bs58')
 
 const mh = require('../src')
 const validCases = require('./fixtures/valid')
@@ -17,83 +16,6 @@ function sample (code, size, hex) {
 }
 
 describe('mh', () => {
-  describe('toHexString', () => {
-    it('valid', () => {
-      validCases.forEach((test) => {
-        const code = test.encoding.code
-        const buf = mh.encode(new Buffer(test.hex, 'hex'), code)
-        expect(
-          mh.toHexString(buf)
-        ).to.be.eql(
-          buf.toString('hex')
-        )
-      })
-    })
-
-    it('invalid', () => {
-      expect(
-        () => mh.toHexString('hello world')
-      ).to.throw(
-        /must be passed a buffer/
-      )
-    })
-  })
-
-  describe('fromHexString', () => {
-    it('valid', () => {
-      validCases.forEach((test) => {
-        const code = test.encoding.code
-        const buf = mh.encode(new Buffer(test.hex, 'hex'), code)
-        expect(
-          mh.fromHexString(buf.toString('hex')).toString('hex')
-        ).to.be.eql(
-          buf.toString('hex')
-        )
-      })
-    })
-  })
-
-  describe('toB58String', () => {
-    it('valid', () => {
-      validCases.forEach((test) => {
-        const code = test.encoding.code
-        const buf = mh.encode(new Buffer(test.hex, 'hex'), code)
-        expect(
-          mh.toB58String(buf)
-        ).to.be.eql(
-          bs58.encode(buf)
-        )
-      })
-    })
-
-    it('invalid', () => {
-      expect(
-        () => mh.toB58String('hello world')
-      ).to.throw(
-        /must be passed a buffer/
-      )
-    })
-  })
-
-  describe('fromB58String', () => {
-    it('valid', () => {
-      const src = 'QmPfjpVaf593UQJ9a5ECvdh2x17XuJYG5Yanv5UFnH3jPE'
-      const expected = new Buffer('122013bf801597d74a660453412635edd8c34271e5998f801fac5d700c6ce8d8e461', 'hex')
-
-      expect(
-        mh.fromB58String(src)
-      ).to.be.eql(
-        expected
-      )
-
-      expect(
-        mh.fromB58String(new Buffer(src))
-      ).to.be.eql(
-        expected
-      )
-    })
-  })
-
   describe('decode', () => {
     it('valid', () => {
       validCases.forEach((test) => {


### PR DESCRIPTION
These are all just functions for converting between representations of a multihash which is absurd to include because js-multihash only needs to do conversion between a buffer and a parsed object. There's no reason to bundle one specific library for encoding/decoding base-58. Since base-58 encoding is a well-defined operation, users should be able to choose whatever base-58 library they want.

The functions `toHexString` & `fromHexString` are even worse because they just add a pointless wrapper to the builtin `Buffer` functions and make any code that uses them harder to understand.
