### PR TITLE
Export constants

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,7 @@
 /* eslint key-spacing: off */
 'use strict'
 
-exports.names = {
+exports.names = Object.freeze({
   'sha1':       0x11,
   'sha2-256':   0x12,
   'sha2-512':   0x13,
@@ -114,9 +114,9 @@ exports.names = {
   'blake2s-240': 0xb25e,
   'blake2s-248': 0xb25f,
   'blake2s-256': 0xb260
-}
+})
 
-exports.codes = {
+exports.codes = Object.freeze({
   0x11: 'sha1',
   0x12: 'sha2-256',
   0x13: 'sha2-512',
@@ -230,9 +230,9 @@ exports.codes = {
   0xb25e: 'blake2s-240',
   0xb25f: 'blake2s-248',
   0xb260: 'blake2s-256'
-}
+})
 
-exports.defaultLengths = {
+exports.defaultLengths = Object.freeze({
   0x11: 20,
   0x12: 32,
   0x13: 64,
@@ -344,4 +344,4 @@ exports.defaultLengths = {
   0xb25e: 0x1e,
   0xb25f: 0x1f,
   0xb260: 0x20
-}
+})

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,11 @@
 const bs58 = require('bs58')
 
 const cs = require('./constants')
+
+exports.names = cs.names
+exports.codes = cs.codes
+exports.defaultLengths = cs.defaultLengths
+
 const varint = require('varint')
 
 /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,6 +10,7 @@ const bufeq = require('buffer-equal')
 const bs58 = require('bs58')
 
 const mh = require('../src')
+const constants = require('../src/constants')
 const validCases = require('./fixtures/valid')
 const invalidCases = require('./fixtures/invalid')
 
@@ -313,5 +314,19 @@ describe('multihash', () => {
     const multihash = new Buffer('definitely not valid')
 
     expect(() => mh.prefix(multihash)).to.throw()
+  })
+
+  describe('constants', () => {
+    it('exported', () => {
+      expect(mh.names).to.equal(constants.names)
+      expect(mh.codes).to.equal(constants.codes)
+      expect(mh.defaultLengths).to.equal(constants.defaultLengths)
+    })
+
+    it('frozen', () => {
+      expect(Object.isFrozen(mh.names)).to.be.true()
+      expect(Object.isFrozen(mh.codes)).to.be.true()
+      expect(Object.isFrozen(mh.defaultLengths)).to.be.true()
+    })
   })
 })


### PR DESCRIPTION
Export the constants, [like in the go implementation](https://github.com/ipfs/go-ipfs/blob/94b832df861728c65e912935641d08880c341e0a/core/commands/dag/dag.go#L92). Also freeze the constant objects so they don't get altered.