### PR TITLE
Fix failing test

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -185,8 +185,7 @@ describe('multihash', () => {
         ).to.throw()
       })
 
-      const longBuffer = Buffer.from(150)
-      longBuffer.fill('a')
+      const longBuffer = Buffer.alloc(150, 'a')
       expect(
         () => mh.validate(longBuffer)
       ).to.throw()


### PR DESCRIPTION
Buffer.from does not take a number (size), using Buffer.alloc instead.