### PR TITLE
fix: missing id name constant

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@
 'use strict'
 
 exports.names = Object.freeze({
+  'id':         0x0,
   'sha1':       0x11,
   'sha2-256':   0x12,
   'sha2-512':   0x13,


### PR DESCRIPTION
As go [specifies](https://github.com/multiformats/go-multihash/blob/master/multihash.go#L39) the `multihash` ID constant, we should do the same here.

It is used for [libp2p-id](https://github.com/libp2p/go-libp2p-peer/blob/7f219a1e70011a258c5d3e502aef6896c60d03ce/peer.go#L85), and consequently for `IPNS`