### PR TITLE
Allocate several prefixes for various Holochain IDs -> Base58 encoding

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -339,7 +339,10 @@ exports.names = Object.freeze({
   'Skein1024-1000': 0xb3dd,
   'Skein1024-1008': 0xb3de,
   'Skein1024-1016': 0xb3df,
-  'Skein1024-1024': 0xb3e0
+  'Skein1024-1024': 0xb3e0,
+  'holochain-keys': 0x8be634,
+  'holochain-id': 0xf1ae34,
+  'holochain-holo': 0xe3f834
 })
 
 exports.codes = Object.freeze({
@@ -682,7 +685,10 @@ exports.codes = Object.freeze({
   0xb3dd: 'Skein1024-1000',
   0xb3de: 'Skein1024-1008',
   0xb3df: 'Skein1024-1016',
-  0xb3e0: 'Skein1024-1024'
+  0xb3e0: 'Skein1024-1024',
+  0x8be634: 'holochain-keys',
+  0xf1ae34: 'holochain-id',
+  0xe3f834: 'holochain-holo'
 })
 
 exports.defaultLengths = Object.freeze({
@@ -1021,5 +1027,8 @@ exports.defaultLengths = Object.freeze({
   0xb3dd: 0x7d,
   0xb3de: 0x7e,
   0xb3df: 0x7f,
-  0xb3e0: 0x80
+  0xb3e0: 0x80,
+  0x8be634: 0x48,
+  0xf1ae34: 0x48,
+  0xe3f834: 0x48
 })


### PR DESCRIPTION
Identify some Holochain base-128 Varint prefixes and lengths for some of our desired address encodings.  These match prefixes+lengths reserved in the multicodec repo.