### PR TITLE
feat: support identity hashes

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@
 'use strict'
 
 exports.names = Object.freeze({
-  'id':         0x0,
+  'identity':   0x0,
   'sha1':       0x11,
   'sha2-256':   0x12,
   'sha2-512':   0x13,
@@ -343,6 +343,9 @@ exports.names = Object.freeze({
 })
 
 exports.codes = Object.freeze({
+  0x0: 'identity',
+
+  // sha family
   0x11: 'sha1',
   0x12: 'sha2-256',
   0x13: 'sha2-512',
@@ -357,6 +360,7 @@ exports.codes = Object.freeze({
   0x1B: 'keccak-256',
   0x1C: 'keccak-384',
   0x1D: 'keccak-512',
+
   0x22: 'murmur3-128',
   0x23: 'murmur3-32',
 

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ exports.decode = function decode (buf) {
  * @returns {Buffer}
  */
 exports.encode = function encode (digest, code, length) {
-  if (!digest || !code) {
+  if (!digest || code === undefined) {
     throw new Error('multihash encode requires at least two args: digest, code')
   }
 
@@ -154,7 +154,7 @@ exports.coerceCode = function coerceCode (name) {
   let code = name
 
   if (typeof name === 'string') {
-    if (!cs.names[name]) {
+    if (cs.names[name] === undefined) {
       throw new Error(`Unrecognized hash function named: ${name}`)
     }
     code = cs.names[name]
@@ -164,7 +164,7 @@ exports.coerceCode = function coerceCode (name) {
     throw new Error(`Hash function code should be a number. Got: ${code}`)
   }
 
-  if (!cs.codes[code] && !exports.isAppCode(code)) {
+  if (cs.codes[code] === undefined && !exports.isAppCode(code)) {
     throw new Error(`Unrecognized function code: ${code}`)
   }
 

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -28,4 +28,11 @@ module.exports = [{
   },
   hex: '2c26b46b',
   size: 4
+}, {
+  encoding: {
+    code: 0x0,
+    name: 'identity'
+  },
+  hex: '7465737420737472696e6720f09f918d',
+  size: 16
 }]


### PR DESCRIPTION
This has come up a few times recently: [inline IPLD blocks encoded within identity CIDs](https://github.com/ipld/js-ipld-block/issues/47#issuecomment-480001980) and [inline entries](https://github.com/ipld/specs/pull/109#issuecomment-479886917) in IPLD data structures (e.g. a HAMT/Map) encoded with identity CIDs, rather than links to different entities. I think this is an appropriate change here? Basically just removing the falsey coercion of `0x0`.

I've also changed `'id'` to `'identity'` to match the multicodec table. I doubt this is a breaking change because it's not currently possible to use `'id'` anyway.