### PR TITLE
Support zero-length multihash, sync test fixtures with go-multihash

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,8 @@ exports.names = Object.freeze({
   'keccak-512': 0x1D,
   'murmur3-128': 0x22,
   'murmur3-32':  0x23,
+  'md4':         0xd4,
+  'md5':         0xd5,
   'blake2b-8':   0xb201,
   'blake2b-16':  0xb202,
   'blake2b-24':  0xb203,
@@ -363,6 +365,9 @@ exports.codes = Object.freeze({
 
   0x22: 'murmur3-128',
   0x23: 'murmur3-32',
+
+  0xd4: 'md4',
+  0xd5: 'md5',
 
   // blake2
   0xb201: 'blake2b-8',

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,8 @@ exports.decode = function decode (buf) {
     throw new Error('multihash must be a Buffer')
   }
 
-  if (buf.length < 3) {
-    throw new Error('multihash too short. must be > 3 bytes.')
+  if (buf.length < 2) {
+    throw new Error('multihash too short. must be > 2 bytes.')
   }
 
   const code = varint.decode(buf)
@@ -89,8 +89,8 @@ exports.decode = function decode (buf) {
   buf = buf.slice(varint.decode.bytes)
 
   const len = varint.decode(buf)
-  if (len < 1) {
-    throw new Error(`multihash invalid length: 0x${len.toString(16)}`)
+  if (len < 0) {
+    throw new Error(`multihash invalid length: ${len}`)
   }
   buf = buf.slice(varint.decode.bytes)
 

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -72,16 +72,14 @@ module.exports = [
     hex: '2c26b46b68ffc68ff99b453c1d30413413',
     size: 17
   },
-  /* TODO: murmur3 not listed in constants.js
   {
     encoding: {
       code: 0x22,
-      name: 'murmur3'
+      name: 'murmur3-128'
     },
     hex: '243ddb9e',
     size: 4
   },
-  */
   {
     encoding: {
       code: 0x1b,
@@ -113,15 +111,14 @@ module.exports = [
     },
     hex: '4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7',
     size: 64
+  },
+  {
+    encoding: {
+      code: 0xd5,
+      name: 'md5',
+      varint: 'd501'
+    },
+    hex: 'd41d8cd98f00b204e9800998ecf8427e',
+    size: 16
   }
-  /* TODO: md5 not listed in constants.js
-    {
-      encoding: {
-        code: 0xd5,
-        name: 'md5'
-      },
-      hex: 'd41d8cd98f00b204e9800998ecf8427e',
-      size: 16
-    }
-  */
 ]

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -1,38 +1,127 @@
 'use strict'
 
-module.exports = [{
-  encoding: {
-    code: 0x11,
-    name: 'sha1'
+module.exports = [
+  {
+    encoding: {
+      code: 0x11,
+      name: 'sha1'
+    },
+    hex: '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33',
+    size: 20
+  }, {
+    encoding: {
+      code: 0x11,
+      name: 'sha1'
+    },
+    hex: '0beec7b8',
+    size: 4
+  }, {
+    encoding: {
+      code: 0x12,
+      name: 'sha2-256'
+    },
+    hex: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+    size: 32
+  }, {
+    encoding: {
+      code: 0x12,
+      name: 'sha2-256'
+    },
+    hex: '2c26b46b',
+    size: 4
+  }, {
+    encoding: {
+      code: 0x0,
+      name: 'identity'
+    },
+    hex: '7465737420737472696e6720f09f918d',
+    size: 16
   },
-  hex: '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33',
-  size: 20
-}, {
-  encoding: {
-    code: 0x11,
-    name: 'sha1'
+  {
+    encoding: {
+      code: 0x0,
+      name: 'identity'
+    },
+    hex: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+    size: 32
   },
-  hex: '0beec7b8',
-  size: 4
-}, {
-  encoding: {
-    code: 0x12,
-    name: 'sha2-256'
+  /* TODO: zero-length not supported
+  {
+    encoding: {
+      code: 0x00,
+      name: 'identity'
+    },
+    hex: '',
+    size: 0
   },
-  hex: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
-  size: 32
-}, {
-  encoding: {
-    code: 0x12,
-    name: 'sha2-256'
+  */
+  {
+    encoding: {
+      code: 0x11,
+      name: 'sha1'
+    },
+    hex: '0beec7b5',
+    size: 4
   },
-  hex: '2c26b46b',
-  size: 4
-}, {
-  encoding: {
-    code: 0x0,
-    name: 'identity'
+  {
+    encoding: {
+      code: 0xb240,
+      name: 'blake2b-512',
+      varint: 'c0e402'
+    },
+    hex: '2c26b46b68ffc68ff99b453c1d30413413',
+    size: 17
   },
-  hex: '7465737420737472696e6720f09f918d',
-  size: 16
-}]
+  /* TODO: murmur3 not listed in constants.js
+  {
+    encoding: {
+      code: 0x22,
+      name: 'murmur3'
+    },
+    hex: '243ddb9e',
+    size: 4
+  },
+  */
+  {
+    encoding: {
+      code: 0x1b,
+      name: 'keccak-256'
+    },
+    hex: 'f00ba4',
+    size: 3
+  },
+  {
+    encoding: {
+      code: 0x18,
+      name: 'shake-128'
+    },
+    hex: 'f84e95cb5fbd2038863ab27d3cdeac295ad2d4ab96ad1f4b070c0bf36078ef08',
+    size: 32
+  },
+  {
+    encoding: {
+      code: 0x19,
+      name: 'shake-256'
+    },
+    hex: '1af97f7818a28edfdfce5ec66dbdc7e871813816d7d585fe1f12475ded5b6502b7723b74e2ee36f2651a10a8eaca72aa9148c3c761aaceac8f6d6cc64381ed39',
+    size: 64
+  },
+  {
+    encoding: {
+      code: 0x14,
+      name: 'sha3-512'
+    },
+    hex: '4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7',
+    size: 64
+  }
+  /* TODO: md5 not listed in constants.js
+    {
+      encoding: {
+        code: 0xd5,
+        name: 'md5'
+      },
+      hex: 'd41d8cd98f00b204e9800998ecf8427e',
+      size: 16
+    }
+  */
+]

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -45,7 +45,6 @@ module.exports = [
     hex: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
     size: 32
   },
-  /* TODO: zero-length not supported
   {
     encoding: {
       code: 0x00,
@@ -54,7 +53,6 @@ module.exports = [
     hex: '',
     size: 0
   },
-  */
   {
     encoding: {
       code: 0x11,

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,10 +14,14 @@ const validCases = require('./fixtures/valid')
 const invalidCases = require('./fixtures/invalid')
 
 function sample (code, size, hex) {
-  return Buffer.concat([
-    Buffer.from([code, size]),
-    Buffer.from(hex, 'hex')
-  ])
+  const toHex = (i) => {
+    if (typeof i === 'string') {
+      return i
+    }
+    const h = i.toString(16)
+    return h.length % 2 === 1 ? `0${h}` : h
+  }
+  return Buffer.from(`${toHex(code)}${toHex(size)}${hex}`, 'hex')
 }
 
 describe('multihash', () => {
@@ -102,7 +106,7 @@ describe('multihash', () => {
     it('valid', () => {
       validCases.forEach((test) => {
         const code = test.encoding.code
-        const buf = sample(code, test.size, test.hex)
+        const buf = sample(test.encoding.varint || code, test.size, test.hex)
         const name = test.encoding.name
         const d1 = Buffer.from(test.hex, 'hex')
         const length = d1.length
@@ -131,7 +135,7 @@ describe('multihash', () => {
       validCases.forEach((test) => {
         const code = test.encoding.code
         const name = test.encoding.name
-        const buf = sample(code, test.size, test.hex)
+        const buf = sample(test.encoding.varint || code, test.size, test.hex)
         const results = [
           mh.encode(Buffer.from(test.hex, 'hex'), code),
           mh.encode(Buffer.from(test.hex, 'hex'), name)
@@ -172,7 +176,7 @@ describe('multihash', () => {
     it('valid', () => {
       validCases.forEach((test) => {
         expect(
-          () => mh.validate(sample(test.encoding.code, test.size, test.hex))
+          () => mh.validate(sample(test.encoding.varint || test.encoding.code, test.size, test.hex))
         ).to.not.throw()
       })
     })
@@ -180,7 +184,7 @@ describe('multihash', () => {
     it('invalid', () => {
       invalidCases.forEach((test) => {
         expect(
-          () => mh.validate(sample(test.code, test.size, test.hex))
+          () => mh.validate(sample(test.encoding.varint || test.code, test.size, test.hex))
         ).to.throw()
       })
 


### PR DESCRIPTION
Ref: https://github.com/ipld/go-car/issues/26

`new CID(Buffer.from([0x01, 0x55, 0x00, 0x00]))` should be possible, a zero-length identity multihash in a raw codec, basically a `null` CID. It's possible in go-cid / go-multihash because the "too short" check is `< 2`: https://github.com/multiformats/go-multihash/blob/6b39927dce4869bc1726861b65ada415ee1f7fc7/multihash.go#L294-L296 while here it's `< 3`.

Changes:

* It's now `< 2`
* A multihash can now be length = 0, the check is for `< 0` (possible I think because we're decoding "varint" and not "varuint" - in Go it'd be an error in the varuint decoder, or it'd decode as some wildly large number).
* Copied test fixtures from go-multihash to here (a couple were the same, but there's a bunch of new)
* Added a couple of hash codes that aren't here (md4, md5, the latter is used by a test case)
* Changed test fixture runner to also handle an encoded varint coming from the fixture for a couple of test cases that have hash codes that overflow the varint single-byte (>127).