### PR TITLE
chore: use object shorthand for properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ exports.decode = function decode (buf) {
   }
 
   return {
-    code: code,
+    code,
     name: codes[code],
     length: len,
     digest: buf


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: Since the published package is built with aegir this should be good to go ✅ 