### PR TITLE
fix: temp fix for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       "src/*": [
         "dist/src/*",
         "dist/src/*/index"
+      ],
+      "src/": [
+        "dist/src/index"
       ]
     }
   },


### PR DESCRIPTION
This is related with the typeVersions recursive resolve that generates wrong path in the type declarations files.
This fix is temporary to be publish as a patch a follow up PR will do a breaking change and remove typeVersions completely as discussed.